### PR TITLE
Jslint initial dump

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 node_modules
 bower_components
+*~

--- a/bin/polylint.js
+++ b/bin/polylint.js
@@ -11,21 +11,99 @@
 // jshint node:true
 'use strict';
 var polylint = require('../polylint');
+var jsconf_policy = require('../lib/jsconf-policy');
 var colors = require('colors/safe');
+var cliArgs = require("command-line-args");
+var fs = require('fs');
 
-var root, path;
-if (process.argv.length > 3) {
-  root = process.argv[2];
-  path = process.argv[3];
-} else {
-  root = process.cwd();
-  path = process.argv[2];
+var cli = cliArgs([
+  {
+    name: "help",
+    type: Boolean,
+    alias: "h",
+    description: "Print usage."
+  },
+  {
+    name: "verbose",
+    type: Boolean,
+    alias: "v",
+    description: "Writes verbose logging."
+  },
+  {
+    name: "debug",
+    type: Boolean,
+    alias: "g",
+    description: "Writes debugging trace."
+  },
+  {
+    name: "policy",
+    type: String,
+    alias: "p",
+    description: "Your jsconf.json policy file.",
+    defaultValue: null
+  },
+  {
+    name: "input",
+    type: String,
+    alias: "i",
+    defaultOption: true,
+    multiple: true,
+    description: (
+      "Polymer source files."
+        + "  If a directory is specified, it is used as the root"
+        + " for resolving relative URLs in the next input."
+    )
+  }
+]);
+
+var usage = cli.getUsage({
+  header: "polylint checks Polymer apps for problematic code patterns",
+  title: "polylint"
+});
+
+var options = cli.parse();
+
+if (options.help) {
+  console.log(usage);
+  process.exit(0);
 }
 
-if (!path) {
-  console.error("Usage: polylint [workdir] <filename>");
-  process.exit(1);
+// Check options and dump usage if we find problems.
+var inputsOk = true;
+
+var inputs = options.input;
+var policyPath = options.policy;
+
+if (!inputs.length) {
+  console.error('Missing input polymer path');
+  inputsOk = false;
 }
+
+if (!inputsOk) {
+  console.log(usage);
+  process.exit(-1);
+}
+
+var jsconfPolicyPromise = Promise.resolve(null);
+if (options.policy) {
+  jsconfPolicyPromise = new Promise(function (fulfill, reject) {
+    fs.readFile(
+      options.policy,
+      { encoding: 'utf8' },
+      function (err, fileContent) {
+        if (err) {
+          reject(err);
+        } else {
+          try {
+            fulfill(jsconf_policy.fromRequirements(JSON.parse(fileContent)));
+          } catch (ex) {
+            reject(ex);
+          }
+        }
+      });
+  });
+}
+
 
 function prettyPrintWarning(warning) {
   var warning = colors.red(warning.filename) + ":" +
@@ -34,10 +112,74 @@ function prettyPrintWarning(warning) {
   console.log(warning);
 }
 
-polylint(path, {root: root}).then(function(lintWarnings){
-  lintWarnings.forEach(function(warning){
-    prettyPrintWarning(warning);
-  })
-}).catch(function(err){
-  console.log(err.stack);
-});
+console.log('inputs=' + JSON.stringify(inputs));
+// Pair inputs with root directories so that for the command line
+//     polylint.js foo/ foo/foo.html bar.html other/ main.html
+// we kick off three analyses:
+// 1. root='foo/'    path='foo.html'
+// 2. root='',       path='bar.html'
+// 3. root='other/', path='main.html'
+(function processInput(inputIndex) {
+  if (inputIndex === inputs.length) {
+    // We're done.
+    return;  // TODO: exit with a signal indicating whether errors occurred.
+  }
+
+  // Check whether input is a root directory before picking a root and
+  // a path to process.
+  var input = inputs[inputIndex];
+  fs.stat(input, function(err, stats) {
+    var root, path, nextInputIndex;
+    if (err) {
+      console.error('Cannot read input `' + input + '`: ' + err);
+      root = path = null;
+      nextInputIndex = inputIndex + 1;
+    } else if (stats.isDirectory()) {
+      root = input;
+      // Make sure resolution has a path segment to drop.
+      // According to URL rules,
+      // resolving index.html relative to /foo/ produces /foo/index.html, but
+      // resolving index.html relative to /foo produces /index.html
+      // is different from resolving index.html relative to /foo/
+      // This removes any ambiguity between URL resolution rules and file path
+      // resolution which might lead to confusion.
+      if (root !== '' && !/[\/\\]$/.test(root)) {
+        root += '/';
+      }
+      if (inputIndex + 1 === inputs.length) {
+        // If we're only given a directory, look for
+        // index.html in it.
+        path = root + 'index.html';
+        nextInputIndex = inputIndex + 1;
+      } else {
+        path = inputs[inputIndex + 1];
+        nextInputIndex = inputIndex + 2;
+      }
+    } else {
+      root = '';
+      path = input;
+      nextInputIndex = inputIndex + 1;
+    }
+
+    // Finally invoke the analyzer.
+    if (path !== null) {
+      polylint(
+        path,
+        {
+          root: root,
+          jsconfPolicy: jsconfPolicyPromise
+        })
+        .then(function(lintWarnings){
+          lintWarnings.forEach(function(warning){
+            prettyPrintWarning(warning);
+          });
+        })
+        .catch(function(err){
+          console.error(err.stack);
+        });
+    }
+
+    // Process any remaining inputs.
+    processInput(nextInputIndex);
+  });
+}(0));

--- a/lib/jsconf-policy.js
+++ b/lib/jsconf-policy.js
@@ -7,6 +7,7 @@
  * Code distributed by Google as part of the polymer project is also
  * subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
  */
+// jshint esnext:true
 
 
 /**
@@ -23,7 +24,7 @@ const Type = {
   RESTRICTED_METHOD_CALL: 8,
   BANNED_CODE_PATTERN: 9,
   BANNED_PROPERTY_CALL: 10
-}
+};
 
 /**
  * @param {*} typeName
@@ -110,8 +111,8 @@ function OptionalRegExpArray(x) {
         } catch (e) {
           console.error(e);
           throw new Error(
-            'Failed to convert Java-style regex to JavaScript: '
-            + javaSource + ' : ' + e);
+              'Failed to convert Java-style regex to JavaScript: ' +
+              javaSource + ' : ' + e);
         }
       }
       arr[i] = el;
@@ -131,8 +132,8 @@ function OptionalPathFilterFunction(opts) {
   }
   return function (path) {
     var pathWithUnixPathSegmentSeparators = String(path);
-    if (pathWithUnixPathSegmentSeparators.indexOf('/') < 0
-        && pathWithUnixPathSegmentSeparators.indexOf('\\') >= 0) {
+    if (pathWithUnixPathSegmentSeparators.indexOf('/') < 0 &&
+        pathWithUnixPathSegmentSeparators.indexOf('\\') >= 0) {
       // This heuristically massages paths to unix style newlines.
       // CAVEAT: Any regex patterns that want to match paths with
       // back-slashes in them may fail as a result.
@@ -199,8 +200,8 @@ function Requirement(spec) {
     { values: spec.only_apply_to, regexps: spec.only_apply_to_regexp });
   if (this.include && this.exclude) {
     throw new Error(
-      'Requirement cannot specify both whtielist* and only_apply_to*: '
-        + JSON.stringify(spec));
+        'Requirement cannot specify both whtielist* and only_apply_to*: ' +
+        JSON.stringify(spec));
   }
   /** @type {number|null} */
   this.type = OptionalType(spec.type);
@@ -211,8 +212,8 @@ function Requirement(spec) {
 
   if ((this.type === Type.CUSTOM) ^ (this.js_module !== null)) {
     throw new Error(
-      'Only/all custom requirements may/must have a js_module: '
-      + JSON.stringify(spec));
+        'Only/all custom requirements may/must have a js_module: ' +
+        JSON.stringify(spec));
   }
 
   /** @type {!Array.<string>} */
@@ -233,8 +234,8 @@ Policy.prototype.applicableTo = function (path) {
   return this.requirements.filter(
     function (requirement) {
       return (
-        (!requirement.include || requirement.include(path))
-        && !(requirement.exclude && requirement.exclude(path))
+          (!requirement.include || requirement.include(path)) &&
+          !(requirement.exclude && requirement.exclude(path))
       );
     }
   );

--- a/lib/jsconf-policy.js
+++ b/lib/jsconf-policy.js
@@ -1,0 +1,274 @@
+/**
+ * @license
+ * Copyright (c) 2015 The Polymer Project Authors. All rights reserved.
+ * This code may only be used under the BSD style license found at http://polymer.github.io/LICENSE.txt
+ * The complete set of authors may be found at http://polymer.github.io/AUTHORS.txt
+ * The complete set of contributors may be found at http://polymer.github.io/CONTRIBUTORS.txt
+ * Code distributed by Google as part of the polymer project is also
+ * subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
+ */
+
+
+/**
+ * @enum{number}
+ */
+const Type = {
+  CUSTOM: 1,
+  BANNED_DEPENDENCY: 2,
+  BANNED_NAME: 3,
+  BANNED_PROPERTY: 4,
+  BANNED_PROPERTY_READ: 5,
+  BANNED_PROPERTY_WRITE: 6,
+  RESTRICTED_NAME_CALL: 7,
+  RESTRICTED_METHOD_CALL: 8,
+  BANNED_CODE_PATTERN: 9,
+  BANNED_PROPERTY_CALL: 10
+}
+
+/**
+ * @param {*} typeName
+ * @return {Type|null}
+ */
+function OptionalType(typeName) {
+  if (!typeName) { return null; }
+  const type = Type[String(typeName)];
+  if ('number' !== typeof type) {
+    throw new Error('invalid type ' + type + ': ' + JSON.stringify(typeName));
+  }
+  return type;
+}
+
+/**
+ * @param {*} x
+ * @return {string|null} the string form of x if x is not nullish.
+ */
+function OptionalString(x) {
+  return x === null || x === undefined ? null : String(x);
+}
+
+/**
+ * @param {*} x
+ * @return {!Array.<string>|null}
+ *    an array created by mapping elements of x to String(element)
+ *    or null if x is falsey.
+ */
+function OptionalStringArray(x) {
+  if (x) {
+    var arr = [];
+    for (var i = 0, n = x.length; i < n; ++i) {
+      arr[i] = String(x[i]);
+    }
+    return arr;
+  }
+  return null;
+}
+
+/**
+ * @param {*} x
+ * @return {Object.<string,boolean>|null}
+ */
+function OptionalStringSet(x) {
+  const strs = OptionalStringArray(x);
+  if (strs) {
+    const o = Object.create(null);
+    for (var i = 0, n = strs.length; i < n; ++i) {
+      o[strs[i]] = true;
+    }
+    return o;
+  }
+  return null;
+}
+
+/**
+ * @param {*} x
+ * @return {!Array.<RegExp>|null}
+ *    an array created by mapping elements of x to RegExp instances
+ *    or null if x is falsey.
+ */
+function OptionalRegExpArray(x) {
+  if (x) {
+    var arr = [];
+    for (var i = 0, n = x.length; i < n; ++i) {
+      var el = x[i];
+      if (!(el instanceof RegExp)) {
+        var javaSource = String(el);
+        // Make a best effort to map Java's java.util.regex.Pattern format
+        // to JavaScript RegExps.
+        // Known problematic cases:
+        // 1. JavaScript does not support lookbehind. (?<!..)
+        // 2. JavaScript does not support embedded flag regions: (?i:...)
+        var flags = '';
+        // In java, (?i) specifies the case-insensitivity flag.
+        var flagPrefixMatch = javaSource.match(/^\(\?([gimsu])+\)/);
+        if (flagPrefixMatch) {
+          flags = flagPrefixMatch[1];
+          javaSource = javaSource.substring(flagPrefixMatch[0].length);
+        }
+        var source = javaSource;
+        try {
+          el = new RegExp(source, flags);
+        } catch (e) {
+          console.error(e);
+          throw new Error(
+            'Failed to convert Java-style regex to JavaScript: '
+            + javaSource + ' : ' + e);
+        }
+      }
+      arr[i] = el;
+    }
+    return arr;
+  }
+  return null;
+}
+
+function OptionalPathFilterFunction(opts) {
+  const values = opts.values;
+  const regexps = opts.regexps;
+  const valueSet = OptionalStringSet(values);
+  const regexpArr = OptionalRegExpArray(regexps);
+  if (!(valueSet || regexpArr)) {
+    return null;
+  }
+  return function (path) {
+    var pathWithUnixPathSegmentSeparators = String(path);
+    if (pathWithUnixPathSegmentSeparators.indexOf('/') < 0
+        && pathWithUnixPathSegmentSeparators.indexOf('\\') >= 0) {
+      // This heuristically massages paths to unix style newlines.
+      // CAVEAT: Any regex patterns that want to match paths with
+      // back-slashes in them may fail as a result.
+      pathWithUnixPathSegmentSeparators = pathWithUnixPathSegmentSeparators
+        .replace(/\\/g, '/');
+    }
+
+    if (valueSet) {
+      // Try each path prefix in pathWith...
+      var pathPrefix = pathWithUnixPathSegmentSeparators;
+      do {
+        if (valueSet[pathPrefix] === true) {
+          return true;
+        }
+        var lastPathIndex = pathPrefix.length - 1;
+        if (lastPathIndex >= 0 && pathPrefix.charAt(lastPathIndex) === '/') {
+          pathPrefix = pathPrefix.substring(0, lastPathIndex);
+        } else {
+          var lastSlash = pathPrefix.lastIndexOf('/');
+          if (lastSlash < 0) { break; }
+          pathPrefix = pathPrefix.substring(0, lastSlash + 1);
+        }
+      } while (pathPrefix);
+    }
+
+    if (regexpArr) {
+      return regexpArr.some(function (re) {
+        if (re.global) { re.lastIndex = 0; }
+        return re.test(pathWithUnixPathSegmentSeparators);
+      });
+    }
+
+    return false;
+  };
+}
+
+/**
+ * @typedef {
+ *   error_message: ?string,
+ *   whitelist: ?Array.<string>,
+ *   whitelist_regexp: ?Array.<string>,
+ *   only_apply_to: ?Array.<string>,
+ *   only_apply_to_regexp: ?Array.<string>,
+ *   type: ?type,
+ *   value: ?Array.<string>,
+ *   js_module: ?string,
+ *   rule_id: ?string,
+ * }
+ */
+var RequirementSpec;
+
+/**
+ * @param {!RequirementSpec} spec
+ * @constructor
+ */
+function Requirement(spec) {
+  /** @type {string|null} */
+  this.error_message = OptionalString(spec.error_message);
+  /** @type {Function<string>:boolean|null} */
+  this.exclude = OptionalPathFilterFunction(
+    { values: spec.whitelist,     regexps: spec.whitelist_regexp });
+  /** @type {Function<string>:boolean|null} */
+  this.include = OptionalPathFilterFunction(
+    { values: spec.only_apply_to, regexps: spec.only_apply_to_regexp });
+  if (this.include && this.exclude) {
+    throw new Error(
+      'Requirement cannot specify both whtielist* and only_apply_to*: '
+        + JSON.stringify(spec));
+  }
+  /** @type {number|null} */
+  this.type = OptionalType(spec.type);
+  /** @type {Object.<string, boolean>|null} */
+  this.js_module = OptionalString(spec.js_module);
+  /** @type {string|null} */
+  this.rule_id = OptionalString(spec.rule_id);
+
+  if ((this.type === Type.CUSTOM) ^ (this.js_module !== null)) {
+    throw new Error(
+      'Only/all custom requirements may/must have a js_module: '
+      + JSON.stringify(spec));
+  }
+
+  /** @type {!Array.<string>} */
+  this.value = OptionalStringArray(spec.value) || [];
+}
+
+/**
+ * @constructor
+ */
+function Policy(requirements) {
+  this.requirements = requirements.slice();
+}
+/**
+ * @param {string} path
+ * @return {!Array.<Requirement>}
+ */
+Policy.prototype.applicableTo = function (path) {
+  return this.requirements.filter(
+    function (requirement) {
+      return (
+        (!requirement.include || requirement.include(path))
+        && !(requirement.exclude && requirement.exclude(path))
+      );
+    }
+  );
+};
+
+/**
+ * A policy derived from JSConformance requirements.
+ *
+ * @param {!{requirement: Array.<RequirementSpec>}}
+ *   An object following the conventions of
+ *   http://tinyurl.com/jsconformance-docs .
+ *   Values for this parameter may be obtained by parsing the
+ *   JSON representation of
+ *   https://github.com/google/closure-compiler/blob/master
+ *   /src/com/google/javascript/jscomp/conformance.proto
+ * @return {Policy} A policy that allows finding the set of requirements to
+ *    apply to a given file.
+ */
+function fromRequirements(conformanceConfig) {
+  const requirementSpecs = conformanceConfig.requirement;
+  if (!Array.isArray(requirementSpecs)) {
+    throw new Error(
+      'missing requirement array: ' + JSON.stringify(conformanceConfig));
+  }
+  const requirements = requirementSpecs.map(function (requirementSpec) {
+    return new Requirement(requirementSpec);
+  });
+  return new Policy(requirements);
+}
+
+
+module.exports = {
+  fromRequirements: fromRequirements,
+  Type: Type,
+  Policy: Policy,
+  Requirement: Requirement
+};

--- a/package.json
+++ b/package.json
@@ -19,8 +19,9 @@
   "homepage": "https://github.com/PolymerLabs/polylint",
   "dependencies": {
     "colors": "^1.1.0",
+    "command-line-args": "^1.0.0",
     "dom5": "^1.0.2",
-    "hydrolysis": "^1.5.0",
+    "hydrolysis": "^1.15.4",
     "optimist": "^0.6.1",
     "pegjs": "^0.8.0",
     "polymer-expressions": "git://github.com/justinfagnani/polymer-expressions.git"

--- a/sample/jsconf/README.md
+++ b/sample/jsconf/README.md
@@ -1,0 +1,12 @@
+# JSConformance sample files
+
+The JSConformance Linter pass is a port of Closure Compiler's
+[JSConformance pass](https://github.com/google/closure-compiler/wiki/JS-Conformance)
+which checks JavaScript code based on a configurable policy.
+
+This directory contains sample configurations and other files related to testing
+of the port.
+
+The conformance policies can be specified using the JSON form of the
+Conformance protocol buffer described in the
+[JSConformance docs](https://docs.google.com/document/d/13Zx-p-GmgPIEig26dFV4Iy9u6wTOLem8o7ScaqT66lA/view)

--- a/sample/jsconf/closure_conformance.json
+++ b/sample/jsconf/closure_conformance.json
@@ -1,0 +1,504 @@
+{
+  "requirement": [
+    {
+      "error_message": "Arguments.prototype.callee is not allowed. See http:\/\/go\/closure-js-conformance#heading=h.rieqpurr8r5s",
+      "rule_id": "closure:callee",
+      "whitelist": [
+        "javascript\/closure\/base.js",
+        "javascript\/closure\/debug\/",
+        "javascript\/apps\/fava\/debug\/",
+        "javascript\/closure\/testing\/stacktrace.js"
+      ],
+      "type": "BANNED_PROPERTY",
+      "value": [
+        "Arguments.prototype.callee"
+      ]
+    },
+    {
+      "error_message": "@expose is not allowed. See http:\/\/go\/closure-js-conformance#heading=h.qe9fclmgrizi",
+      "rule_id": "closure:expose",
+      "java_class": "com.google.javascript.jscomp.ConformanceRules$BanExpose",
+      "js_module": "./ban_expose.js",
+      "type": "CUSTOM"
+    },
+    {
+      "error_message": "Only Error or Error subclass objects may be thrown. http:\/\/go\/closure-js-conformance#heading=h.r6d19yb3tmj7",
+      "rule_id": "closure:throwOfNonErrorTypes",
+      "whitelist": [
+        "javascript\/closure\/storage\/",
+        "javascript\/apps\/fava\/request\/requestwrapper.js",
+        "third_party\/java\/caja\/",
+        "third_party\/javascript\/closure\/dojo\/dom\/query.js",
+        "third_party\/javascript\/libphonenumber\/i18n\/phonenumbers\/phonenumberutil.js",
+        "third_party\/java_src\/shindig"
+      ],
+      "java_class": "com.google.javascript.jscomp.ConformanceRules$BanThrowOfNonErrorTypes",
+      "js_module": "./ban_throw_of_non_error_types.js",
+      "type": "CUSTOM"
+    },
+    {
+      "error_message": "Global declarations are not allowed. See http:\/\/go\/boq-js-conformance#heading=h.u8jj7d95sdqt",
+      "rule_id": "closure:globalVars",
+      "whitelist_regexp": [
+        "Post.*bootstrap_module"
+      ],
+      "whitelist": [
+        "javascript\/apps\/xid\/xid.js",
+        "javascript\/closure\/base.js",
+        "javascript\/closure\/labs\/testing\/",
+        "javascript\/closure\/locale\/locale.js",
+        "javascript\/closure\/testing\/",
+        "javascript\/closure\/tweak\/testhelpers.js"
+      ],
+      "java_class": "com.google.javascript.jscomp.ConformanceRules$BanGlobalVars",
+      "js_module": "./ban_global_vars.js",
+      "type": "CUSTOM"
+    },
+    {
+      "error_message": "References to \"this\" that are typed as \"unknown\" are not allowed. See http:\/\/go\/boq-js-conformance#heading=h.otnizo1x6tsu",
+      "rule_id": "closure:unknownThis",
+      "whitelist": [
+        "javascript\/closure\/base.js",
+        "javascript\/closure\/debug\/errorhandler.js",
+        "javascript\/closure\/functions\/functions.js",
+        "javascript\/closure\/memoize\/memoize.js",
+        "javascript\/closure\/testing\/",
+        "javascript\/jsaction\/actionflow.js"
+      ],
+      "java_class": "com.google.javascript.jscomp.ConformanceRules$BanUnknownThis",
+      "js_module": "./ban_unknown_this.js",
+      "type": "CUSTOM"
+    },
+    {
+      "error_message": "Window.prototype.postMessage is not allowed. See http:\/\/go\/closure-js-conformance#bookmark=h.qlgxsckksx7h",
+      "rule_id": "closure:postMessage",
+      "whitelist": [
+        "javascript\/closure\/async\/nexttick.js",
+        "javascript\/closure\/net\/xpc\/nativemessagingtransport.js"
+      ],
+      "type": "BANNED_PROPERTY_CALL",
+      "value": [
+        "Window.prototype.postMessage"
+      ]
+    },
+    {
+      "error_message": "All client side storage APIs must be pre-approved. See http:\/\/go\/closure-js-conformance#heading=h.34g5m9mhid6s",
+      "rule_id": "closure:storage",
+      "whitelist": [
+        "javascript\/closure\/debug\/fancywindow.js",
+        "javascript\/closure\/fs\/",
+        "javascript\/closure\/storage\/"
+      ],
+      "type": "BANNED_PROPERTY",
+      "value": [
+        "Window.prototype.localStorage",
+        "Window.prototype.sessionStorage",
+        "Window.prototype.indexedDB",
+        "Window.prototype.openDatabase",
+        "Window.prototype.requestFileSystem",
+        "Window.prototype.webkitRequestFileSystem"
+      ]
+    },
+    {
+      "error_message": "eval is not allowed. See http:\/\/go\/closure-js-conformance#heading=h.g2a0hz9upjap",
+      "rule_id": "closure:eval",
+      "whitelist": [
+        "javascript\/closure\/json\/json.js",
+        "javascript\/closure\/base.js",
+        "javascript\/closure\/datasource\/jsxmlhttpdatasource.js"
+      ],
+      "type": "BANNED_NAME",
+      "value": [
+        "eval"
+      ]
+    },
+    {
+      "error_message": "Assignment to Element.prototype.innerHTML is not allowed. See http:\/\/go\/closure-js-conformance#heading=h.m90l6v6oop3n",
+      "rule_id": "closure:innerHtml",
+      "whitelist": [
+        "javascript\/closure\/dom\/safe.js",
+        "javascript\/security\/jsvir\/htmlsanitizer.js",
+        "javascript\/closure\/string\/string.js",
+        "javascript\/closure\/soy\/soy.js",
+        "javascript\/closure\/labs\/structs\/map_perf.js",
+        "javascript\/closure\/testing\/",
+        "javascript\/closure\/editor\/",
+        "javascript\/closure\/dom\/browserrange\/ierange.js",
+        "javascript\/closure\/dom\/dom.js"
+      ],
+      "type": "BANNED_PROPERTY_WRITE",
+      "value": [
+        "Element.prototype.innerHTML"
+      ]
+    },
+    {
+      "error_message": "Assignment to Element.prototype.outerHTML is not allowed. See http:\/\/go\/closure-js-conformance#heading=h.m90l6v6oop3n",
+      "rule_id": "closure:outerHtml",
+      "whitelist": [
+        "javascript\/closure\/dom\/safe.js",
+        "javascript\/closure\/editor\/"
+      ],
+      "type": "BANNED_PROPERTY_WRITE",
+      "value": [
+        "Element.prototype.outerHTML"
+      ]
+    },
+    {
+      "error_message": "Using Document.prototype.write is not allowed. Use goog.dom.safe.documentWrite instead. See http:\/\/go\/secure-dom-api-conformance#heading=h.l1izirxareia.",
+      "rule_id": "closure:documentWrite",
+      "whitelist": [
+        "javascript\/closure\/async\/nexttick.js",
+        "javascript\/closure\/base.js",
+        "javascript\/closure\/dom\/safe.js",
+        "javascript\/closure\/editor\/icontent.js",
+        "javascript\/closure\/testing\/"
+      ],
+      "type": "BANNED_PROPERTY",
+      "value": [
+        "Document.prototype.write",
+        "Document.prototype.writeln"
+      ]
+    },
+    {
+      "error_message": "Assignment to Location.prototype.href is not allowed. See http:\/\/go\/closure-js-conformance#bookmark=h.4tdpmw32tbn",
+      "rule_id": "closure:locationHref",
+      "whitelist": [
+        "javascript\/closure\/dom\/safe.js",
+        "javascript\/closure\/net\/xpc\/iframepollingtransport.js",
+        "javascript\/closure\/history\/history.js"
+      ],
+      "type": "BANNED_PROPERTY_WRITE",
+      "value": [
+        "Location.prototype.href"
+      ]
+    },
+    {
+      "error_message": "Assignment to Window.prototype.location is not allowed. See http:\/\/go\/closure-js-conformance#bookmark=h.4tdpmw32tbn",
+      "rule_id": "closure:location",
+      "type": "BANNED_PROPERTY_WRITE",
+      "value": [
+        "Window.prototype.location"
+      ]
+    },
+    {
+      "error_message": "Assignment to .href property of Anchor, Link, etc elements, is not allowed. See http:\/\/go\/closure-js-conformance#bookmark=h.n6f3isbsmrpw",
+      "rule_id": "closure:href",
+      "whitelist": [
+        "javascript\/closure\/dom\/safe.js",
+        "javascript\/closure\/editor\/plugins\/linkdialogplugin.js",
+        "javascript\/closure\/testing\/testrunner.js",
+        "javascript\/closure\/editor\/link.js"
+      ],
+      "type": "BANNED_PROPERTY_WRITE",
+      "value": [
+        "Element.prototype.href",
+        "StyleSheet.prototype.href",
+        "CSSImportRule.prototype.href"
+      ]
+    },
+    {
+      "error_message": "Assignment to property requires a TrustedResourceUrl via goog.dom.safe. See http:\/\/go\/closure-js-conformance#bookmark=h.5112zw6es8ng",
+      "rule_id": "closure:trustedResourceUrlProperties",
+      "whitelist": [
+        "javascript\/closure\/dom\/safe.js",
+        "javascript\/closure\/editor\/field.js",
+        "javascript\/closure\/net\/xpc\/iframerelaytransport.js",
+        "javascript\/closure\/testing\/multitestrunner.js"
+      ],
+      "type": "BANNED_PROPERTY_WRITE",
+      "value": [
+        "HTMLElement.prototype.manifest",
+        "HTMLEmbedElement.prototype.src",
+        "HTMLFrameElement.prototype.src",
+        "HTMLIFrameElement.prototype.src",
+        "HTMLLinkElement.prototype.rel",
+        "HTMLObjectElement.prototype.data",
+        "HTMLScriptElement.prototype.src",
+        "HTMLTrackElement.prototype.src"
+      ]
+    },
+    {
+      "error_message": "goog.html.legacyconversions are not allowed. See http:\/\/go\/secure-dom-api-conformance#bookmark=kix.l9bbqpox2s3q for details.",
+      "rule_id": "closure:legacyHtml",
+      "whitelist": [
+        "javascript\/closure\/html\/legacyconversions.js",
+        "javascript\/closure\/dom\/iframe.js",
+        "javascript\/closure\/i18n\/bidiformatter.js",
+        "javascript\/closure\/net\/crossdomainrpc.js",
+        "javascript\/closure\/ui\/ac\/richremotearraymatcher.js",
+        "javascript\/closure\/history\/history.js",
+        "javascript\/closure\/ui\/bubble.js",
+        "javascript\/closure\/ui\/dialog.js",
+        "javascript\/closure\/ui\/media\/flashobject.js",
+        "javascript\/closure\/ui\/media\/mediamodel.js",
+        "javascript\/closure\/ui\/drilldownrow.js",
+        "javascript\/closure\/ui\/prompt.js",
+        "javascript\/closure\/ui\/tooltip.js",
+        "javascript\/closure\/ui\/tree\/basenode.js"
+      ],
+      "type": "BANNED_NAME",
+      "value": [
+        "goog.html.legacyconversions"
+      ]
+    },
+    {
+      "error_message": "String style in goog.dom.iframe.createBlank is not allowed. Use goog.html.SafeStyle instead. See http:\/\/go\/secure-dom-api-conformance#bookmark=kix.l9bbqpox2s3q.",
+      "rule_id": "closure:legacyIframeCreateBlank",
+      "type": "RESTRICTED_NAME_CALL",
+      "value": [
+        "goog.dom.iframe.createBlank:function(?, !goog.html.SafeStyle=, ...?)"
+      ]
+    },
+    {
+      "error_message": "goog.dom.iframe.writeContent is not allowed. Use goog.dom.iframe.writeSafeContent instead. See http:\/\/go\/secure-dom-api-conformance#bookmark=kix.l9bbqpox2s3q.",
+      "rule_id": "closure:legacyIframeWriteContent",
+      "whitelist": [
+        "javascript\/closure\/dom\/iframe.js"
+      ],
+      "type": "BANNED_NAME",
+      "value": [
+        "goog.dom.iframe.writeContent"
+      ]
+    },
+    {
+      "error_message": "String html or style in goog.dom.iframe.createWithContent is not allowed. Use goog.html.SafeHtml and goog.html.SafeStyle instead. See http:\/\/go\/secure-dom-api-conformance#bookmark=kix.l9bbqpox2s3q.",
+      "rule_id": "closure:legacyIframeCreateWithContent",
+      "type": "RESTRICTED_NAME_CALL",
+      "value": [
+        "goog.dom.iframe.createWithContent:function(?, !goog.html.SafeHtml=, !goog.html.SafeHtml=, !goog.html.SafeStyle=, ...?)"
+      ]
+    },
+    {
+      "error_message": "goog.net.CrossDomainRpc#sendRequest is not allowed. No alternative currently exists, contact ise-hardening@ for help. See http:\/\/go\/secure-dom-api-conformance#bookmark=kix.l9bbqpox2s3q.",
+      "rule_id": "closure:legacyCrossDomainRpcSendRequest",
+      "whitelist": [
+        "javascript\/closure\/net\/crossdomainrpc.js"
+      ],
+      "type": "BANNED_PROPERTY",
+      "value": [
+        "goog.net.CrossDomainRpc.prototype.sendRequest"
+      ]
+    },
+    {
+      "error_message": "goog.net.CrossDomainRpc.send is not allowed. No alternative currently exists, contact ise-hardening@ for help. See http:\/\/go\/secure-dom-api-conformance#bookmark=kix.l9bbqpox2s3q.",
+      "rule_id": "closure:legacyCrossDomainRpcSend",
+      "whitelist": [
+        "javascript\/closure\/net\/crossdomainrpc.js"
+      ],
+      "type": "BANNED_NAME",
+      "value": [
+        "goog.net.CrossDomainRpc.send"
+      ]
+    },
+    {
+      "error_message": "goog.ui.ac.RichRemoteArrayMatcher is not allowed. No alternative currently exists, contact ise-hardening@ for help. See http:\/\/go\/secure-dom-api-conformance#bookmark=kix.l9bbqpox2s3q.",
+      "rule_id": "closure:legacyRichRemoteArrayMatcher",
+      "whitelist": [
+        "javascript\/closure\/ui\/ac\/richremote.js",
+        "javascript\/closure\/ui\/ac\/richremotearraymatcher.js"
+      ],
+      "type": "BANNED_NAME",
+      "value": [
+        "goog.ui.ac.RichRemoteArrayMatcher"
+      ]
+    },
+    {
+      "error_message": "goog.ui.ac.RichRemote is not allowed. No alternative currently exists, contact ise-hardening@ for help. See http:\/\/go\/secure-dom-api-conformance#bookmark=kix.l9bbqpox2s3q.",
+      "rule_id": "closure:legacyRichRemote",
+      "whitelist": [
+        "javascript\/closure\/ui\/ac\/richremote.js"
+      ],
+      "type": "BANNED_NAME",
+      "value": [
+        "goog.ui.ac.RichRemote"
+      ]
+    },
+    {
+      "error_message": "String URL in goog.History is not allowed. Use goog.html.TrustedResourceUrl instead. See http:\/\/go\/secure-dom-api-conformance#bookmark=kix.l9bbqpox2s3q.",
+      "rule_id": "closure:legacyHistory",
+      "type": "RESTRICTED_NAME_CALL",
+      "value": [
+        "goog.History:function(?, !goog.html.TrustedResourceUrl=, ...?)"
+      ]
+    },
+    {
+      "error_message": "String html in goog.ui.Bubble is not allowed. Use goog.html.SafeHtml instead. See http:\/\/go\/secure-dom-api-conformance#bookmark=kix.l9bbqpox2s3q.",
+      "rule_id": "closure:legacyBubble",
+      "type": "RESTRICTED_NAME_CALL",
+      "value": [
+        "goog.ui.Bubble:function(!goog.html.SafeHtml, ...?)",
+        "goog.ui.Bubble:function(Element, ...?)"
+      ]
+    },
+    {
+      "error_message": "goog.ui.Dialog#setContent is not allowed. Use setSafeHtmlContent instead. See http:\/\/go\/secure-dom-api-conformance#bookmark=kix.l9bbqpox2s3q.",
+      "rule_id": "closure:dialogHtml",
+      "type": "BANNED_PROPERTY",
+      "value": [
+        "goog.ui.Dialog.prototype.setContent"
+      ]
+    },
+    {
+      "error_message": "String promptHtml in goog.ui.Prompt is not allowed. Use goog.html.SafeHtml instead. See http:\/\/go\/secure-dom-api-conformance#bookmark=kix.l9bbqpox2s3q.",
+      "rule_id": "closure:promptHtml",
+      "type": "RESTRICTED_NAME_CALL",
+      "value": [
+        "goog.ui.Prompt:function(?, !goog.html.SafeHtml, ...?)"
+      ]
+    },
+    {
+      "error_message": "String URL in goog.ui.media.FlashObject is not allowed. Use goog.html.TrustedResourceUrl instead. See http:\/\/go\/secure-dom-api-conformance#bookmark=kix.l9bbqpox2s3q.",
+      "rule_id": "closure:flashUrl",
+      "type": "RESTRICTED_NAME_CALL",
+      "value": [
+        "goog.ui.media.FlashObject:function(!goog.html.TrustedResourceUrl, ...?)"
+      ]
+    },
+    {
+      "error_message": "String URL in goog.ui.media.MediaModel.Player is not allowed. Use goog.html.TrustedResourceUrl instead. See http:\/\/go\/secure-dom-api-conformance#bookmark=kix.l9bbqpox2s3q.",
+      "rule_id": "closure:mediaPlayerUrl",
+      "whitelist": [
+        "javascript\/closure\/ui\/media\/googlevideo.js",
+        "javascript\/closure\/ui\/media\/vimeo.js",
+        "javascript\/closure\/ui\/media\/youtube.js"
+      ],
+      "type": "RESTRICTED_NAME_CALL",
+      "value": [
+        "goog.ui.media.MediaModel.Player:function(!goog.html.TrustedResourceUrl, ...?)"
+      ]
+    },
+    {
+      "error_message": "String URL in goog.ui.media.MediaModel.Player#setUrl is not allowed. Use goog.html.TrustedResourceUrl instead. See http:\/\/go\/secure-dom-api-conformance#bookmark=kix.l9bbqpox2s3q.",
+      "rule_id": "closure:mediaPlayerSetUrl",
+      "type": "RESTRICTED_METHOD_CALL",
+      "value": [
+        "goog.ui.media.MediaModel.Player.prototype.setUrl:function(!goog.html.TrustedResourceUrl)"
+      ]
+    },
+    {
+      "error_message": "goog.ui.DrilldownRow.unsafeCreate is not allowed. Use goog.ui.DrilldownRow constructor instead. See http:\/\/go\/secure-dom-api-conformance#bookmark=kix.l9bbqpox2s3q.",
+      "rule_id": "closure:legacyDrilldownRowUnsafeCreate",
+      "whitelist": [
+        "javascript\/closure\/ui\/drilldownrow.js"
+      ],
+      "type": "BANNED_NAME",
+      "value": [
+        "goog.ui.DrilldownRow.unsafeCreate"
+      ]
+    },
+    {
+      "error_message": "goog.ui.Tooltip#setHtml is not allowed. Use setSafeHtml instead. See http:\/\/go\/secure-dom-api-conformance#bookmark=kix.l9bbqpox2s3q.",
+      "rule_id": "closure:tooltipHtml",
+      "type": "BANNED_PROPERTY",
+      "value": [
+        "goog.ui.Tooltip.prototype.setHtml"
+      ]
+    },
+    {
+      "error_message": "String html in goog.ui.tree.BaseNode is not allowed. Use goog.html.SafeHtml instead. See http:\/\/go\/secure-dom-api-conformance#bookmark=kix.l9bbqpox2s3q.",
+      "rule_id": "closure:treeBaseNodeHtml",
+      "whitelist": [
+        "javascript\/closure\/ui\/tree\/"
+      ],
+      "type": "RESTRICTED_NAME_CALL",
+      "value": [
+        "goog.ui.tree.BaseNode:function(!goog.html.SafeHtml, ...?)",
+        "goog.ui.tree.TreeNode:function(!goog.html.SafeHtml, ...?)",
+        "goog.ui.tree.TreeControl:function(!goog.html.SafeHtml, ...?)"
+      ]
+    },
+    {
+      "error_message": "First parameter opt_html of goog.ui.tree.TreeControl#createNode is not allowed. Use setSafeHtml on the created object instead. See http:\/\/go\/secure-dom-api-conformance#bookmark=kix.l9bbqpox2s3q.",
+      "rule_id": "closure:treeControlHtml",
+      "type": "RESTRICTED_METHOD_CALL",
+      "value": [
+        "goog.ui.tree.TreeControl.prototype.createNode:function()"
+      ]
+    },
+    {
+      "error_message": "goog.ui.tree.BaseNode#setAfterLabelHtml is not allowed. Use setAfterLabelSafeHtml instead. See http:\/\/go\/secure-dom-api-conformance#bookmark=kix.l9bbqpox2s3q.",
+      "rule_id": "closure:treeBaseNodeSetAfterLabelHtml",
+      "type": "BANNED_PROPERTY",
+      "value": [
+        "goog.ui.tree.BaseNode.prototype.setAfterLabelHtml"
+      ]
+    },
+    {
+      "error_message": "goog.ui.tree.BaseNode#setHtml is not allowed. Use setSafeHtml instead. See http:\/\/go\/secure-dom-api-conformance#bookmark=kix.l9bbqpox2s3q.",
+      "rule_id": "closure:treeBaseNodeSetHtml",
+      "type": "BANNED_PROPERTY",
+      "value": [
+        "goog.ui.tree.BaseNode.prototype.setHtml"
+      ]
+    },
+    {
+      "error_message": "goog.i18n.BidiFormatter#spanWrap(?, true) is not allowed. Use spanWrapSafeHtml instead. See http:\/\/go\/secure-dom-api-conformance#bookmark=kix.l9bbqpox2s3q.",
+      "rule_id": "closure:bidiSpanWrapHtml",
+      "type": "BANNED_CODE_PATTERN",
+      "value": [
+        "\/**\n * @param {goog.i18n.BidiFormatter} bidiFormatter\n * @param {?} str\n *\/\nfunction template(bidiFormatter, str) {\n  bidiFormatter.spanWrap(str, true);\n}\n",
+        "\/**\n * @param {goog.i18n.BidiFormatter} bidiFormatter\n * @param {?} str\n * @param {?} dirReset\n *\/\nfunction template(bidiFormatter, str, dirReset) {\n  bidiFormatter.spanWrap(str, true, dirReset);\n}\n"
+      ]
+    },
+    {
+      "error_message": "goog.i18n.BidiFormatter#spanWrapWithKnownDir(?, ?, true) is not allowed. Use spanWrapSafeHtmlWithKnownDir instead. See http:\/\/go\/secure-dom-api-conformance#bookmark=kix.l9bbqpox2s3q.",
+      "rule_id": "closure:bidiSpanWrapWithKnownDirHtml",
+      "whitelist": [
+        "javascript\/template\/soy\/soyutis_usegoog.js"
+      ],
+      "type": "BANNED_CODE_PATTERN",
+      "value": [
+        "\/**\n * @param {goog.i18n.BidiFormatter} bidiFormatter\n * @param {?} dir\n * @param {?} str\n *\/\nfunction template(bidiFormatter, dir, str) {\n  bidiFormatter.spanWrapWithKnownDir(dir, str, true);\n}\n",
+        "\/**\n * @param {goog.i18n.BidiFormatter} bidiFormatter\n * @param {?} dir\n * @param {?} str\n * @param {?} dirReset\n *\/\nfunction template(bidiFormatter, dir, str, dirReset) {\n  bidiFormatter.spanWrapWithKnownDir(dir, str, true, dirReset);\n}\n"
+      ]
+    },
+    {
+      "error_message": "Use of goog.debug.Logger.getLogger is not allowed. See http:\/\/go\/closure-js-conformance#heading=h.ikz9vmftcy92",
+      "rule_id": "closure:getLogger",
+      "whitelist": [
+        "javascript\/closure\/debug\/",
+        "javascript\/closure\/log\/",
+        "javascript\/apps\/chat\/",
+        "javascript\/apps\/fava\/debug\/"
+      ],
+      "type": "BANNED_NAME",
+      "value": [
+        "goog.debug.Logger.getLogger"
+      ]
+    },
+    {
+      "error_message": "Direct use of goog.debug.Logger is not allowed. See http:\/\/go\/closure-js-conformance#heading=h.ikz9vmftcy92",
+      "rule_id": "closure:logger",
+      "whitelist": [
+        "javascript\/closure\/debug\/",
+        "javascript\/closure\/log\/",
+        "javascript\/apps\/fava\/debug\/",
+        "javascript\/apps\/fava\/testing\/automation",
+        "javascript\/apps\/fava\/component\/componentlogger.js"
+      ],
+      "type": "BANNED_PROPERTY",
+      "value": [
+        "goog.debug.Logger.prototype.log",
+        "goog.debug.Logger.prototype.shout",
+        "goog.debug.Logger.prototype.severe",
+        "goog.debug.Logger.prototype.warning",
+        "goog.debug.Logger.prototype.info",
+        "goog.debug.Logger.prototype.config",
+        "goog.debug.Logger.prototype.fine",
+        "goog.debug.Logger.prototype.finer",
+        "goog.debug.Logger.prototype.finest",
+        "goog.debug.Logger.prototype.logRecord",
+        "goog.debug.Logger.prototype.getName",
+        "goog.debug.Logger.prototype.addHandler",
+        "goog.debug.Logger.prototype.removeHandler",
+        "goog.debug.Logger.prototype.getParent",
+        "goog.debug.Logger.prototype.getChildren",
+        "goog.debug.Logger.prototype.getLevel",
+        "goog.debug.Logger.prototype.setLevel",
+        "goog.debug.Logger.prototype.getEffectiveLevel",
+        "goog.debug.Logger.prototype.isLoggable",
+        "goog.debug.Logger.prototype.getLogRecord"
+      ]
+    }
+  ]
+}

--- a/test/jsconf-policy-test.js
+++ b/test/jsconf-policy-test.js
@@ -28,7 +28,7 @@ describe(
     it(
       'applicableTo("javascript/closure/dom/safe.js")',
       function () {
-        const closureDomSafeRequirements = p.applicableTo(
+        var closureDomSafeRequirements = p.applicableTo(
           'javascript/closure/dom/safe.js');
         assert(closureDomSafeRequirements.length === 34);
       }
@@ -36,14 +36,14 @@ describe(
     it(
       'applicableTo("Post.*bootstrap_module whitelist_regexp")',
       function () {
-        const bm_init = p.applicableTo('Post/foo/bootstrap_module/init.js');
+        var bm_init = p.applicableTo('Post/foo/bootstrap_module/init.js');
         assert(bm_init.length === 39);
       }
     );
     it(
       'applicableTo("not/mentioned/in/any/path/matcher.js")',
       function () {
-        const nm_init = p.applicableTo('not/mentioned/in/any/path/matcher.js');
+        var nm_init = p.applicableTo('not/mentioned/in/any/path/matcher.js');
         assert(nm_init.length === 40);
       }
     );

--- a/test/jsconf-policy-test.js
+++ b/test/jsconf-policy-test.js
@@ -1,0 +1,51 @@
+/**
+ * @license
+ * Copyright (c) 2015 The Polymer Project Authors. All rights reserved.
+ * This code may only be used under the BSD style license found at http://polymer.github.io/LICENSE.txt
+ * The complete set of authors may be found at http://polymer.github.io/AUTHORS.txt
+ * The complete set of contributors may be found at http://polymer.github.io/CONTRIBUTORS.txt
+ * Code distributed by Google as part of the polymer project is also
+ * subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
+ */
+
+var policy = require('../lib/jsconf-policy');
+var assert = require('assert');
+var fs = require('fs');
+
+describe(
+  'policy.fromRequirements("closure_conformance.json")',
+  function () {
+    var closure_conformance_json = JSON.parse(
+      fs.readFileSync('./sample/jsconf/closure_conformance.json', { encoding: 'UTF-8' }));
+    var p = policy.fromRequirements(closure_conformance_json);
+    it(
+      'requirements.length',
+      function () {
+        assert(p instanceof policy.Policy);
+        assert(p.requirements.length === 40);
+      }
+    );
+    it(
+      'applicableTo("javascript/closure/dom/safe.js")',
+      function () {
+        const closureDomSafeRequirements = p.applicableTo(
+          'javascript/closure/dom/safe.js');
+        assert(closureDomSafeRequirements.length === 34);
+      }
+    );
+    it(
+      'applicableTo("Post.*bootstrap_module whitelist_regexp")',
+      function () {
+        const bm_init = p.applicableTo('Post/foo/bootstrap_module/init.js');
+        assert(bm_init.length === 39);
+      }
+    );
+    it(
+      'applicableTo("not/mentioned/in/any/path/matcher.js")',
+      function () {
+        const nm_init = p.applicableTo('not/mentioned/in/any/path/matcher.js');
+        assert(nm_init.length === 40);
+      }
+    );
+  }
+);


### PR DESCRIPTION
This does an initial dump of some JSConf policy stuff and reworks flag parsing as discussed with AJO.

This change prepares the ground for some subsequent changes:
1. A change that threads options through to linters
2. A change that adds a linter that implements a JSConformance policy check using the options to identify a policy
3. A change that unifies warning/error reporting so that an option can control the kinds of problems that should be treated as errors and that does process.exit with a zero response code only when there are no errors.  The goal here is to allow bin/polylint to be used as a presubmit gate based on its exit code.
