### PR TITLE
bin/polylint: should only exit with response code 0 when there are no fatal errors

### DIFF
--- a/bin/polylint.js
+++ b/bin/polylint.js
@@ -10,7 +10,6 @@
  */
 // jshint node:true
 'use strict';
-var process = require('process');
 var polylint = require('../polylint');
 var jsconf_policy = require('../lib/jsconf-policy');
 var colors = require('colors/safe');
@@ -123,7 +122,7 @@ if (options.policy) {
 }
 
 
-var root = options.root || '';
+var root = options.root || process.cwd();
 // Make sure resolution has a path segment to drop.
 // According to URL rules,
 // resolving index.html relative to /foo/ produces /foo/index.html, but


### PR DESCRIPTION
The heart of the change is 

``` js
   // Exit with a non-zero status code if there was a fatal error so that this
   // executable can be used as a presubmit gate in a shell script like
   //    if polylint ...; then
   //      # proceed with submit
   //    else
   //      # don't
   //    fi
```
