### PR TITLE
pass options to linters 

### DIFF
--- a/polylint.js
+++ b/polylint.js
@@ -24,17 +24,21 @@ var polylint = function polylint(path, options) {
   if (!options) {
     options = {};
   }
+  if (!('redirect' in options) {
+    options.redirect = "bower_components";
+  }
   options.attachAST = true;
   options.filter = function(){
     return false;
   };
-  options.redirect = "bower_components";
   return hydrolysis.Analyzer.analyze(path, options).then(function(analyzer){
-    var lintErrors = [];
-    for (var linter in linters) {
-      lintErrors = lintErrors.concat(linters[linter](analyzer, path));
+    var allWarnings = [];
+    for (var linterName in linters) {
+      var linter = linters[linterName];
+      var warnings = linter(analyzer, path, options);
+      allWarnings = allWarnings.concat(warnings);
     }
-    return lintErrors;
+    return allWarnings;
   }).catch(function(err){
     throw err;
   });

--- a/polylint.js
+++ b/polylint.js
@@ -24,13 +24,13 @@ var polylint = function polylint(path, options) {
   if (!options) {
     options = {};
   }
-  if (!('redirect' in options)) {
-    options.redirect = "bower_components";
-  }
   options.attachAST = true;
   options.filter = function(){
     return false;
   };
+  if (!('redirect' in options)) {
+    options.redirect = "bower_components";
+  }
   return hydrolysis.Analyzer.analyze(path, options).then(function(analyzer){
     var allWarnings = [];
     for (var linterName in linters) {

--- a/polylint.js
+++ b/polylint.js
@@ -24,7 +24,7 @@ var polylint = function polylint(path, options) {
   if (!options) {
     options = {};
   }
-  if (!('redirect' in options) {
+  if (!('redirect' in options)) {
     options.redirect = "bower_components";
   }
   options.attachAST = true;


### PR DESCRIPTION
This allows the jsconformance checker to get the policy passed via flags to bin/polylint.js

I also tweaked the code to make sure that the --bowerdir flag value is not clobbered,
and to make sure that linters is not passed as the value of `this` to linter functions to avoid
unintentional mutation of that object.

Also renamed `linterErrors` to `warnings` since that is the terminology used in bin/polylint.js
