### PR TITLE
Avoid duplicating the root path for absolute paths

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "dom5": "^1.0.2",
     "hydrolysis": "^1.17.0",
     "optimist": "^0.6.1",
+    "path-is-absolute": "^1.0.0",
     "pegjs": "^0.8.0"
   },
   "devDependencies": {


### PR DESCRIPTION
When the root path is set from CWD and an absolute path is supplied for
input, strip the root path from the input path before passing it on to
hydrolysis to prevent the root path from being used twice.

Needed for PolymerLabs/polylint#22, instead of Polymer/hydrolysis#168 or
Polymer/hydrolysis#180