### PR TITLE
Add checks for WAI-ARIA accessibility attributes

### DIFF
--- a/lib/linters.js
+++ b/lib/linters.js
@@ -208,6 +208,52 @@ function isProblematicAttribute(attr) {
   return false;
 }
 
+function isA11yAttribute(attr) {
+  // list taken from WAI-ARIA spec
+  // aria-* http://www.w3.org/TR/wai-aria/states_and_properties#state_prop_def
+  // role: http://www.w3.org/TR/wai-aria/host_languages#host_general_role
+  switch(attr.name.toLowerCase()) {
+    case 'aria-activedescendant':
+    case 'aria-atomic':
+    case 'aria-autocomplete':
+    case 'aria-busy':
+    case 'aria-checked':
+    case 'aria-controls':
+    case 'aria-describedby':
+    case 'aria-disabled':
+    case 'aria-dropeffect':
+    case 'aria-expanded':
+    case 'aria-flowto':
+    case 'aria-grabbed':
+    case 'aria-haspopup':
+    case 'aria-hidden':
+    case 'aria-invalid':
+    case 'aria-label':
+    case 'aria-labelledby':
+    case 'aria-level':
+    case 'aria-live':
+    case 'aria-multiline':
+    case 'aria-multiselectable':
+    case 'aria-orientation':
+    case 'aria-owns':
+    case 'aria-posinset':
+    case 'aria-pressed':
+    case 'aria-readonly':
+    case 'aria-relevant':
+    case 'aria-required':
+    case 'aria-selected':
+    case 'aria-setsize':
+    case 'aria-sort':
+    case 'aria-valuemax':
+    case 'aria-valuemin':
+    case 'aria-valuenow':
+    case 'aria-valuetext':
+    case 'role':
+      return true;
+  }
+  return false;
+}
+
 function lintErrorFromNode(node, message, fatal) {
   return new LintError(node.__ownerDocument, node.__locationDetail, message, fatal);
 }
@@ -372,7 +418,7 @@ var linters = {
     analyzer.elements.forEach(function(element) {
       var attributes = attributeBindingExpressions(analyzer, element.is);
       attributes.forEach(function(attr){
-        if (isProblematicAttribute(attr)) {
+        if (isProblematicAttribute(attr) || isA11yAttribute(attr)) {
           var node = attr.node;
           badBindings.push(lintErrorFromNode(node, "The expression " + attr.expression +
               " bound to the attribute '"+ attr.name +

--- a/sample/imports/a11y-attributes.html
+++ b/sample/imports/a11y-attributes.html
@@ -1,0 +1,29 @@
+<!--
+@license
+Copyright (c) 2015 The Polymer Project Authors. All rights reserved.
+This code may only be used under the BSD style license found at http://polymer.github.io/LICENSE.txt
+The complete set of authors may be found at http://polymer.github.io/AUTHORS.txt
+The complete set of contributors may be found at http://polymer.github.io/CONTRIBUTORS.txt
+Code distributed by Google as part of the polymer project is also
+subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
+-->
+<dom-module id="a11y-attributes">
+  <template>
+    <div
+      role="textbox"
+      aria-required$="[[required]]"
+      aria-label="[[label]]"
+    >
+    </div>
+  </template>
+</dom-module>
+
+<script>
+  Polymer({
+    is: 'a11y-attributes',
+    properties: {
+      required: Boolean,
+      label: String
+    }
+  });
+</script>

--- a/sample/my-element-collection.html
+++ b/sample/my-element-collection.html
@@ -12,3 +12,4 @@
 <link rel="import" href="imports/observer-not-function.html">
 <link rel="import" href="imports/string-literals.html">
 <link rel="import" href="imports/unbalanced-delimiters.html">
+<link rel="import" href="imports/a11y-attributes.html">

--- a/test/linter-test.js
+++ b/test/linter-test.js
@@ -154,4 +154,13 @@ suite('Linter', function() {
     });
   });
 
+  test('a11y attributes', function() {
+    var w = findWarnings(warnings, 'a11y-attributes');
+    assert.equal(w.length, 1);
+    // aria-label is bound to a property with $=
+    var first = w[0];
+    assert.equal(first.location.line, 12);
+    assert.include(first.message, 'aria-label');
+  });
+
 });


### PR DESCRIPTION
This list is exhaustive for the aria attributes, but does not check those attributes for validity

Fixes #14 Warn when inputs are missing aria-labels