### PR TITLE
Use path.sep instead of '/' to fix #53

### DIFF
--- a/bin/polylint.js
+++ b/bin/polylint.js
@@ -155,7 +155,7 @@ var root = options.root || process.cwd();
 // This removes any ambiguity between URL resolution rules and file path
 // resolution which might lead to confusion.
 if (root !== '' && !/[\/\\]$/.test(root)) {
-  root += '/';
+  root += path.sep;
 }
 
 


### PR DESCRIPTION
Simple fix so that polylint works on windows when input file is specified using an absolute path.