### PR TITLE
Make sure to run exit helper

### DIFF
--- a/lib/cli.js
+++ b/lib/cli.js
@@ -321,7 +321,7 @@ function runWithOptions(options) {
         process.exit(fatalFailureOccurred ? 1 : 0);
     };
 
-    resolve(lintPromise);
+    resolve(lintPromise.then(exit));
   });
 }
 


### PR DESCRIPTION
The exit() function is never used so the process never exits with
anything but return code 0.