### PR TITLE
Correct binding expression regex to match non greedily (Fixes #113)

### DIFF
--- a/lib/expressions.js
+++ b/lib/expressions.js
@@ -56,7 +56,7 @@ var ExpressionParser = function ExpressionParser() {
 ExpressionParser.prototype = {
 
   extractBindingExpression: function (text) {
-    var match = text.match(/\{\{(.*)\}\}/) || text.match(/\[\[(.*)\]\]/);
+    var match = text.match(/\{\{(.*?)\}\}/) || text.match(/\[\[(.*?)\]\]/);
     var expression;
     if (match && match.length === 2) {
       expression = match[1];

--- a/sample/imports/compound-binding.html
+++ b/sample/imports/compound-binding.html
@@ -1,0 +1,30 @@
+<!--
+@license
+Copyright (c) 2015 The Polymer Project Authors. All rights reserved.
+This code may only be used under the BSD style license found at http://polymer.github.io/LICENSE.txt
+The complete set of authors may be found at http://polymer.github.io/AUTHORS.txt
+The complete set of contributors may be found at http://polymer.github.io/CONTRIBUTORS.txt
+Code distributed by Google as part of the polymer project is also
+subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
+-->
+<dom-module id="compound-binding">
+  <template>
+    <span>{{one}} {{two}}</span>
+  </template>
+</dom-module>
+
+<script>
+Polymer({
+  is: 'compound-binding',
+  properties: {
+    one: {
+      type: String,
+      value: 'We\'re in this'
+    },
+    two: {
+      type: String,
+      value: 'together'
+    }
+  }
+});
+</script>

--- a/sample/imports/property-not-found.html
+++ b/sample/imports/property-not-found.html
@@ -7,7 +7,7 @@ The complete set of contributors may be found at http://polymer.github.io/CONTRI
 Code distributed by Google as part of the polymer project is also
 subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
 -->
-<dom-module id="compound-binding">
+<dom-module id="property-not-found">
   <template>
     <span>[[nested]]</span>
     <span>{{nested.this.that.other}}</span>
@@ -17,7 +17,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
 <script>
 Polymer({
-  is: 'compound-binding',
+  is: 'property-not-found',
   properties: {
     /**
      * A super nifty property.

--- a/sample/my-element-collection.html
+++ b/sample/my-element-collection.html
@@ -3,6 +3,7 @@
 <link rel="import" href="imports/bound-variables-declared.html">
 <link rel="import" href="imports/bind-to-class.html">
 <link rel="import" href="imports/bind-to-data.html">
+<link rel="import" href="imports/compound-binding.html">
 <link rel="import" href="imports/computed-binding.html">
 <link rel="import" href="imports/dom-module-after-polymer.html">
 <link rel="import" href="imports/element-not-defined.html">

--- a/sample/my-element-collection.html
+++ b/sample/my-element-collection.html
@@ -3,7 +3,6 @@
 <link rel="import" href="imports/bound-variables-declared.html">
 <link rel="import" href="imports/bind-to-class.html">
 <link rel="import" href="imports/bind-to-data.html">
-<link rel="import" href="imports/compound-binding.html">
 <link rel="import" href="imports/computed-binding.html">
 <link rel="import" href="imports/dom-module-after-polymer.html">
 <link rel="import" href="imports/element-not-defined.html">
@@ -12,6 +11,7 @@
 <link rel="import" href="imports/missing-is.html">
 <link rel="import" href="imports/number-literals.html">
 <link rel="import" href="imports/observer-not-function.html">
+<link rel="import" href="imports/property-not-found.html">
 <link rel="import" href="imports/string-literals.html">
 <link rel="import" href="imports/unbalanced-delimiters.html">
 <link rel="import" href="imports/whitespace.html">

--- a/test/linter-test.js
+++ b/test/linter-test.js
@@ -65,6 +65,11 @@ suite('Linter', function() {
     assert.include(warning.message, 'myVar');
   });
 
+  test('compound-binding', function() {
+    var w = findWarnings(warnings, 'compound-binding');
+    assert.equal(w.length, 0);
+  });
+
   test('computed-binding', function() {
     var w = findWarnings(warnings, 'computed-binding');
     assert.equal(w.length, 2);

--- a/test/linter-test.js
+++ b/test/linter-test.js
@@ -65,15 +65,6 @@ suite('Linter', function() {
     assert.include(warning.message, 'myVar');
   });
 
-  test('compound-binding', function() {
-    var w = findWarnings(warnings, 'compound-binding');
-    assert.equal(w.length, 1);
-    var warning = w[0];
-    assert.equal(warning.location.line, 14);
-    assert.equal(warning.location.column, 11);
-    assert.include(warning.message, 'nestedz');
-  });
-
   test('computed-binding', function() {
     var w = findWarnings(warnings, 'computed-binding');
     assert.equal(w.length, 2);
@@ -145,6 +136,15 @@ suite('Linter', function() {
     assert.equal(fourth.location.line, 29);
     assert.equal(fourth.location.column, 19);
     assert.include(fourth.message, '_brokenObserver2Changed');
+  });
+
+  test('property-not-found', function() {
+    var w = findWarnings(warnings, 'property-not-found');
+    assert.equal(w.length, 1);
+    var warning = w[0];
+    assert.equal(warning.location.line, 14);
+    assert.equal(warning.location.column, 11);
+    assert.include(warning.message, 'nestedz');
   });
 
   test('string-literals', function() {


### PR DESCRIPTION
With this fix, the binding expressions regex will correctly match binding expressions on the same line individually rather than greedily matching between both of their `{{` and `}}`.

I also renamed the oddly named compound-binding.html test component to property-not-found.html, and made a new compound-binding.html with an actual compound binding, which is the use case that usually hits this bug.