### PR TITLE
Add a version switch to the command line

### DIFF
--- a/lib/cli.js
+++ b/lib/cli.js
@@ -20,6 +20,7 @@ var path = require('path');
 // jshint -W079
 var Promise = global.Promise || require('es6-promise').Promise;
 // jshint +W079
+var packageJson = require('../package.json');
 
 var argumentDefinitions = [
   {
@@ -106,6 +107,13 @@ var argumentDefinitions = [
     description: (
       "Only report errors on specified input files, not from their dependencies."
     )
+  },
+  {
+    name: "version",
+    type: Boolean,
+    description: (
+      "Print the version"
+    )
   }
 ];
 
@@ -122,6 +130,9 @@ function run(env, args, stdout) {
 
     if (options.help) {
       console.log(usage);
+      resolve();
+    } else if(options.version) {
+      console.log('polylint version ', packageJson.version);
       resolve();
     } else {
       return runWithOptions(options);


### PR DESCRIPTION
Fixes #84.

Added a simple version switch to the CLI which outputs the package.json's version field.
