### PR TITLE
add linter for undefined and misspelt behaviors

### DIFF
--- a/lib/linters.js
+++ b/lib/linters.js
@@ -495,6 +495,38 @@ var linters = {
     });
     return undefinedElements;
   },
+  behaviorNotDefined: function behaviourNotDefined(analyzer) {
+    var badBehaviors = [];
+    analyzer.elements.forEach(function(element) {
+      var misspeltProperty = element.properties.find(function(property) {
+        return property.name === 'behaviours' && property.type === 'Array';
+      });
+
+      if(misspeltProperty !== undefined) {
+          badBehaviors.push(lintErrorFromJavascript(
+              element.scriptElement,
+              misspeltProperty.javascriptNode,
+              element.contentHref,
+              "Property '" + misspeltProperty.name + "' is possibly misspelled, did you mean 'behavior'?"
+          ));
+          return;
+      }
+
+      if(element.behaviors === undefined) {
+        return;
+      }
+
+      element.behaviors.forEach(function(behavior) {
+        if(!analyzer.behaviorsByName.hasOwnProperty(behavior)) {
+          badBehaviors.push(lintErrorFromNode(
+              element.scriptElement,
+              "Behavior '" + behavior + "' not found"
+          ));
+        }
+      });
+    });
+    return badBehaviors;
+  },
   nativeAttributeBinding: function nativeAttributeBinding(analyzer) {
     var badBindings = [];
     analyzer.elements.forEach(function(element) {

--- a/sample/imports/behavior-not-defined.html
+++ b/sample/imports/behavior-not-defined.html
@@ -1,0 +1,19 @@
+<!--
+@license
+Copyright (c) 2015 The Polymer Project Authors. All rights reserved.
+This code may only be used under the BSD style license found at http://polymer.github.io/LICENSE.txt
+The complete set of authors may be found at http://polymer.github.io/AUTHORS.txt
+The complete set of contributors may be found at http://polymer.github.io/CONTRIBUTORS.txt
+Code distributed by Google as part of the polymer project is also
+subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
+-->
+<dom-module id="behavior-not-defined">
+<script>
+Polymer({
+  is: 'behavior-not-defined',
+  behaviors: [
+    Polymer.NonExistentBehavior
+  ]
+});
+</script>
+</dom-module>

--- a/sample/imports/misspelt-behavior.html
+++ b/sample/imports/misspelt-behavior.html
@@ -1,0 +1,17 @@
+<!--
+@license
+Copyright (c) 2015 The Polymer Project Authors. All rights reserved.
+This code may only be used under the BSD style license found at http://polymer.github.io/LICENSE.txt
+The complete set of authors may be found at http://polymer.github.io/AUTHORS.txt
+The complete set of contributors may be found at http://polymer.github.io/CONTRIBUTORS.txt
+Code distributed by Google as part of the polymer project is also
+subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
+-->
+<dom-module id="misspelt-behavior">
+<script>
+Polymer({
+  is: 'misspelt-behavior',
+  behaviours: []
+});
+</script>
+</dom-module>

--- a/sample/my-element-collection.html
+++ b/sample/my-element-collection.html
@@ -15,3 +15,5 @@
 <link rel="import" href="imports/string-literals.html">
 <link rel="import" href="imports/unbalanced-delimiters.html">
 <link rel="import" href="imports/whitespace.html">
+<link rel="import" href="imports/misspelt-behavior.html">
+<link rel="import" href="imports/behavior-not-defined.html">

--- a/test/linter-test.js
+++ b/test/linter-test.js
@@ -38,6 +38,22 @@ suite('Linter', function() {
     });
   });
 
+  test('misspelt-behavior', function() {
+    var w = findWarnings(warnings, 'misspelt-behavior');
+    assert.equal(w.length, 1);
+    var warning = w[0];
+    assert.equal(warning.location.line, 14);
+    assert.equal(warning.location.column, 3);
+  });
+
+  test('behavior-not-defined', function() {
+    var w = findWarnings(warnings, 'behavior-not-defined');
+    assert.equal(w.length, 1);
+    var warning = w[0];
+    assert.equal(warning.location.line, 11);
+    assert.equal(warning.location.column, 1);
+  });
+
   test('bind-to-class', function() {
     var w = findWarnings(warnings, 'bind-to-class');
     assert.equal(w.length, 1);


### PR DESCRIPTION
Fixes #112 and #70.

Added a `behaviorNotDefined` linter which checks for a possible misspelling of `behavior` (due to UK english and such using `behaviour`) and missing behaviours.

Using this linter does mean you will see a warning twice, however. This is because Hydrolysis also throws its own warning [here](https://github.com/Polymer/hydrolysis/blob/cec64f94c57955ec1a449f0a5c8cfe79d5f25ef7/src/ast-utils/docs.ts#L150).

Also, is there any issue using `Array.prototype.find` here? It is supported in later node versions.
