### PR TITLE
add a linter for camel case attributes on custom elements

### DIFF
--- a/lib/linters.js
+++ b/lib/linters.js
@@ -478,6 +478,39 @@ var linters = {
     });
     return unorderedModules;
   },
+  camelCaseAttributes: function camelCaseAttributes(analyzer) {
+    var camelAttrs = [];
+    var customElements = analyzer.nodeWalkAllDocuments(isCustomElement);
+    customElements.forEach(function(element){
+      if(!analyzer.elementsByTagName.hasOwnProperty(element.tagName)) {
+        return;
+      }
+
+      var camelProps = analyzer.elementsByTagName[element.tagName]
+        .properties
+        .filter(function(prop) {
+          return /[a-z][A-Z]/.test(prop.name);
+        }).reduce(function(p, c) {
+          p[c.name.toLowerCase()] = c.name;
+          return p;
+        }, {});
+
+      element.attrs.forEach(function(attr) {
+        var val = attr.name;
+        var camelVal;
+        if(camelProps.hasOwnProperty(val)) {
+          camelVal = camelProps[val];
+          camelAttrs.push(lintErrorFromNode(
+            element,
+            "<" + element.tagName + "> should use dash-case " +
+            "for the property '" + camelVal + "', like " +
+            "'" + caseMap.camelToDashCase(camelVal) + "'"
+          ));
+        }
+      });
+    });
+    return camelAttrs;
+  },
   elementNotDefined: function elementNotDefined(analyzer) {
     var undefinedElements = [];
     var customElements = analyzer.nodeWalkAllDocuments(isCustomElement);

--- a/sample/imports/camel-case-attributes.html
+++ b/sample/imports/camel-case-attributes.html
@@ -1,0 +1,32 @@
+<!--
+@license
+Copyright (c) 2016 The Polymer Project Authors. All rights reserved.
+This code may only be used under the BSD style license found at http://polymer.github.io/LICENSE.txt
+The complete set of authors may be found at http://polymer.github.io/AUTHORS.txt
+The complete set of contributors may be found at http://polymer.github.io/CONTRIBUTORS.txt
+Code distributed by Google as part of the polymer project is also
+subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
+-->
+<dom-module id="camel-case-attributes">
+  <template>
+    <camel-case-attribute fooBar="baz"></camel-case-attribute>
+  </template>
+  <script>
+  Polymer({
+    is: 'camel-case-attributes'
+  });
+  </script>
+</dom-module>
+
+<dom-module id="camel-case-attribute">
+  <script>
+  Polymer({
+    is: 'camel-case-attribute',
+    properties: {
+      fooBar: {
+        type: String
+      }
+    }
+  });
+  </script>
+</dom-module>

--- a/sample/my-element-collection.html
+++ b/sample/my-element-collection.html
@@ -15,3 +15,4 @@
 <link rel="import" href="imports/string-literals.html">
 <link rel="import" href="imports/unbalanced-delimiters.html">
 <link rel="import" href="imports/whitespace.html">
+<link rel="import" href="imports/camel-case-attributes.html">

--- a/test/linter-test.js
+++ b/test/linter-test.js
@@ -38,6 +38,14 @@ suite('Linter', function() {
     });
   });
 
+  test('camel-case-attributes', function() {
+    var w = findWarnings(warnings, 'camel-case-attributes');
+    assert.equal(w.length, 1);
+    var warning = w[0];
+    assert.equal(warning.location.line, 12);
+    assert.equal(warning.location.column, 5);
+  });
+
   test('bind-to-class', function() {
     var w = findWarnings(warnings, 'bind-to-class');
     assert.equal(w.length, 1);


### PR DESCRIPTION
Fixes #58.

Simply takes any camel cased properties from the element definition and checks if a lowercased version exists on the instance of it (the tag).

This works because parse5 normalises attributes, such that `fooBar` becomes `foobar`. So if we have a property named `fooBar` and our parse5 node has `foobar`, we know it was originally written as `<our-el fooBar>`.
